### PR TITLE
chore: sync package-lock.json version to 0.5.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "rn-checkout",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "rn-checkout",
-      "version": "0.5.1",
+      "version": "0.5.2",
       "dependencies": {
         "@hookform/resolvers": "^3.9.0",
         "@next/third-parties": "^14.2.7",


### PR DESCRIPTION
## Problem
package-lock.json version was not updated when bumping to 0.5.2.

## Proposed Solution
Sync package-lock.json version to match package.json (0.5.2).